### PR TITLE
Enable use in simulations by adding current_time parameters

### DIFF
--- a/PID.py
+++ b/PID.py
@@ -34,14 +34,14 @@ class PID:
     """PID Controller
     """
 
-    def __init__(self, P=0.2, I=0.0, D=0.0):
+    def __init__(self, P=0.2, I=0.0, D=0.0, current_time=None):
 
         self.Kp = P
         self.Ki = I
         self.Kd = D
 
         self.sample_time = 0.00
-        self.current_time = time.time()
+        self.current_time = current_time if current_time is not None else time.time()
         self.last_time = self.current_time
 
         self.clear()
@@ -61,7 +61,7 @@ class PID:
 
         self.output = 0.0
 
-    def update(self, feedback_value):
+    def update(self, feedback_value, current_time=None):
         """Calculates PID value for given reference feedback
 
         .. math::
@@ -75,7 +75,7 @@ class PID:
         """
         error = self.SetPoint - feedback_value
 
-        self.current_time = time.time()
+        self.current_time = current_time if current_time is not None else time.time()
         delta_time = self.current_time - self.last_time
         delta_error = error - self.last_error
 


### PR DESCRIPTION
## Rationale
I needed this controller to run in simulated time for [model based design](https://en.wikipedia.org/wiki/Model-based_design). Since I simulate a process that takes several hours, I did not want to run the simulation in real-time.

## Summary of changes
The changes are minimal, the system still automatically relies on `time.time()` as current time value, but if you pass in the _optional_ value for `current_time` in `__init__` and/or `update`, it uses that value instead.

## Use case

A simplified example with an `oven` object that is heated based on the observed values of the `thermometer` that measures the oven temperature. The power used to heat the oven is determined by the output of the PID controller.
```
for time in range(0, 6000)
    pid.update(thermometer.measure(oven), time)
    oven.heat(pid.output)
```
Hereafter the measured temperatures are plotted against the time values and the controller behaviour is evaluated.

As long as my thermometer and oven models are close enough to their real world counterparts, I can test and tune the controller in the simulation and it will work on the real oven.